### PR TITLE
refactor: Make minimum macOS version supported to be 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "SimilaritySearchKit",
     platforms: [
-        .macOS(.v13),
-        .iOS(.v16),
+        .macOS(.v11),
+        .iOS(.v15),
     ],
     products: [
         .library(

--- a/Sources/SimilaritySearchKit/Core/Embeddings/EmbeddingProtocols.swift
+++ b/Sources/SimilaritySearchKit/Core/Embeddings/EmbeddingProtocols.swift
@@ -12,7 +12,7 @@ import Combine
 
 /// A protocol for embedding models that can generate vector representations of text.
 /// Implement this protocol to support different models for encoding text into vectors.
-@available(macOS 12.0, iOS 15.0, *)
+@available(macOS 11.0, iOS 15.0, *)
 public protocol EmbeddingsProtocol {
     /// The associated tokenizer type for the embedding model.
     associatedtype TokenizerType

--- a/Sources/SimilaritySearchKit/Core/Embeddings/Models/NativeEmbeddings.swift
+++ b/Sources/SimilaritySearchKit/Core/Embeddings/Models/NativeEmbeddings.swift
@@ -8,7 +8,7 @@
 import Foundation
 import NaturalLanguage
 
-@available(macOS 12.0, iOS 15.0, *)
+@available(macOS 11.0, iOS 15.0, *)
 public class NativeEmbeddings: EmbeddingsProtocol {
     public let model = ModelActor()
     public let tokenizer: any TokenizerProtocol

--- a/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
+++ b/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
@@ -16,7 +16,7 @@ public typealias SimilarityMetricType = SimilarityIndex.SimilarityMetricType
 public typealias TextSplitterType = SimilarityIndex.TextSplitterType
 public typealias VectorStoreType = SimilarityIndex.VectorStoreType
 
-@available(macOS 12.0, iOS 15.0, *)
+@available(macOS 11.0, iOS 15.0, *)
 public class SimilarityIndex {
     // MARK: - Properties
 
@@ -203,7 +203,7 @@ public class SimilarityIndex {
 
 // MARK: - CRUD
 
-@available(macOS 12.0, iOS 15.0, *)
+@available(macOS 11.0, iOS 15.0, *)
 extension SimilarityIndex {
     // MARK: Create
 


### PR DESCRIPTION
This change should allow programmers to use this library in apps with low minimum supported versions (macOS 11, iOS 15). In versions where no feature is supported, they can fallback to other methods (for example, NaturalLanguage).