### PR TITLE
BinaryStore with compressed binary representation, removed some fatal errors, made saveIndex and loadIndex public methods

### DIFF
--- a/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
+++ b/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
@@ -169,7 +169,7 @@ public class SimilarityIndex {
                 return SearchResult(id: item.id, score: score, text: item.text, metadata: item.metadata)
             } else {
                 print("Failed to find item with id '\(id)' in indexItems.")
-                return SearchResult(id: "000000", score: 0.0, text: "fail", metadata: []
+                return SearchResult(id: "000000", score: 0.0, text: "fail", metadata: [:])
             }
         }
     }

--- a/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
+++ b/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
@@ -246,8 +246,9 @@ extension SimilarityIndex {
     }
 
     public func addItems(_ items: [IndexItem]) {
+        Task {
         for item in items {
-            Task {
+            
                 await self.addItem(id: item.id, text: item.text, metadata: item.metadata, embedding: item.embedding)
             }
         }

--- a/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
+++ b/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
@@ -116,7 +116,7 @@ public class SimilarityIndex {
         if let testVector = await indexModel.encode(sentence: "Test sentence") {
             dimension = testVector.count
         } else {
-            Error("Failed to generate a test input vector.")
+            fatalError("Failed to generate a test input vector.")
         }
     }
 
@@ -267,7 +267,7 @@ extension SimilarityIndex {
     public func updateItem(id: String, text: String? = nil, embedding: [Float]? = nil, metadata: [String: String]? = nil) {
         // Check if the provided embedding has the correct dimension
         if let embedding = embedding, embedding.count != dimension {
-            Error("Dimension mismatch, expected \(dimension), saw \(embedding.count)")
+            fatalError("Dimension mismatch, expected \(dimension), saw \(embedding.count)")
         }
 
         // Find the item with the specified id

--- a/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
+++ b/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
@@ -169,6 +169,7 @@ public class SimilarityIndex {
                 return SearchResult(id: item.id, score: score, text: item.text, metadata: item.metadata)
             } else {
                 print("Failed to find item with id '\(id)' in indexItems.")
+                return SearchResult(id: "000000", score: 0.0, text: "fail", metadata: []
             }
         }
     }

--- a/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
+++ b/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
@@ -116,7 +116,7 @@ public class SimilarityIndex {
         if let testVector = await indexModel.encode(sentence: "Test sentence") {
             dimension = testVector.count
         } else {
-            fatalError("Failed to generate a test input vector.")
+            Error("Failed to generate a test input vector.")
         }
     }
 
@@ -129,7 +129,8 @@ public class SimilarityIndex {
         } else {
             // Encoding needed before adding to index
             guard let encoded = await indexModel.encode(sentence: text) else {
-                fatalError("Failed to encode text.")
+                print("Failed to encode text. \(text)")
+                return Array(repeating: Float(0), count: dimension)
             }
             return encoded
         }
@@ -140,7 +141,8 @@ public class SimilarityIndex {
     public func search(_ query: String, top resultCount: Int? = nil, metric: DistanceMetricProtocol? = nil) async -> [SearchResult] {
         let resultCount = resultCount ?? 5
         guard let queryEmbedding = await indexModel.encode(sentence: query) else {
-            fatalError("Failed to generate query embedding for '\(query)'.")
+            print("Failed to generate query embedding for '\(query)'.")
+            return []
         }
 
         var indexIds: [String] = []
@@ -166,7 +168,7 @@ public class SimilarityIndex {
             if let item = getItem(id: id) {
                 return SearchResult(id: item.id, score: score, text: item.text, metadata: item.metadata)
             } else {
-                fatalError("Failed to find item with id '\(id)' in indexItems.")
+                print("Failed to find item with id '\(id)' in indexItems.")
             }
         }
     }
@@ -222,7 +224,7 @@ extension SimilarityIndex {
         }
 
         if let embeddings = embeddings, embeddings.count != ids.count {
-            fatalError("Embeddings array length must be the same as ids array length.")
+            fatalError("Embeddings array length must be the same as ids array length. \(embeddings.count) vs \(ids.count)")
         }
 
         await withTaskGroup(of: Void.self) { taskGroup in
@@ -265,7 +267,7 @@ extension SimilarityIndex {
     public func updateItem(id: String, text: String? = nil, embedding: [Float]? = nil, metadata: [String: String]? = nil) {
         // Check if the provided embedding has the correct dimension
         if let embedding = embedding, embedding.count != dimension {
-            fatalError("Dimension mismatch, expected \(dimension), saw \(embedding.count)")
+            Error("Dimension mismatch, expected \(dimension), saw \(embedding.count)")
         }
 
         // Find the item with the specified id

--- a/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
+++ b/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
@@ -305,7 +305,7 @@ extension SimilarityIndex {
 
 @available(macOS 13.0, iOS 16.0, *)
 extension SimilarityIndex {
-    func saveIndex(toDirectory path: URL? = nil, name: String? = nil) throws -> URL {
+    public func saveIndex(toDirectory path: URL? = nil, name: String? = nil) throws -> URL {
         let indexName = name ?? self.indexName
         let basePath: URL
 
@@ -323,7 +323,7 @@ extension SimilarityIndex {
         return savedVectorStore
     }
 
-    func loadIndex(fromDirectory path: URL? = nil, name: String? = nil) throws -> [IndexItem]? {
+    public func loadIndex(fromDirectory path: URL? = nil, name: String? = nil) throws -> [IndexItem]? {
         let indexName = name ?? self.indexName
         let basePath: URL
 

--- a/Sources/SimilaritySearchKit/Core/Persistence/BinaryStore/BinaryStore.swift
+++ b/Sources/SimilaritySearchKit/Core/Persistence/BinaryStore/BinaryStore.swift
@@ -1,0 +1,75 @@
+//
+//  BinaryStore.swift
+//
+//
+//  Created by Michael Jelly on 7/14/23.
+//
+import Compression
+import Foundation
+
+public class BinaryStore: VectorStoreProtocol {
+    public func saveIndex(items: [IndexItem], to url: URL, as name: String) throws -> URL {
+        let fileURL = url.appendingPathComponent("\(name).dat")
+        var data = Data()
+
+        for item in items {
+            let encoder = JSONEncoder()
+            let itemData = try encoder.encode(item)
+            var length = Int32(itemData.count)
+            var lengthData = Data()
+            lengthData.append(UnsafeBufferPointer(start: &length, count: 1))
+            data.append(lengthData)
+            data.append(itemData)
+        }
+        let nsdata = data as NSData
+        let compressedData = try nsdata.compressed(using: .lzma)
+
+        do {
+            try compressedData.write(to: fileURL, options: .atomic)
+        } catch {
+            throw error
+        }
+
+        return fileURL
+    }
+
+    public func loadIndex(from url: URL) throws -> [IndexItem] {
+        let compressedData = try Data(contentsOf: url)
+        let decompressedData = compressedData.withUnsafeBytes { ptr -> Data in
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: compressedData.count * 5) // assuming the compressed data is at most 5 times smaller than the original data
+            let decompressedSize = compression_decode_buffer(buffer, compressedData.count * 5, ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), compressedData.count, nil, COMPRESSION_LZMA)
+            return Data(bytes: buffer, count: decompressedSize)
+        }
+
+        var items: [IndexItem] = []
+        var start = decompressedData.startIndex
+
+        while start < decompressedData.endIndex {
+            let lengthData = decompressedData[start..<(start+4)]
+            let length: Int32 = lengthData.withUnsafeBytes { $0.pointee }
+            start += 4
+            let end = start + Int(length)
+            let itemData = decompressedData[start..<end]
+            let decoder = JSONDecoder()
+            let item = try decoder.decode(IndexItem.self, from: itemData)
+            items.append(item)
+            start = end
+        }
+
+        return items
+    }
+
+
+  public func listIndexes(at url: URL) -> [URL] {
+    let fileManager = FileManager.default
+    do {
+      let files = try fileManager.contentsOfDirectory(
+        at: url, includingPropertiesForKeys: nil, options: [])
+      let datFiles = files.filter { $0.pathExtension == "dat" }
+      return datFiles
+    } catch {
+      print("Error listing indexes: \(error)")
+      return []
+    }
+  }
+}

--- a/Sources/SimilaritySearchKit/Core/Persistence/BinaryStore/BinaryStore.swift
+++ b/Sources/SimilaritySearchKit/Core/Persistence/BinaryStore/BinaryStore.swift
@@ -8,6 +8,9 @@ import Compression
 import Foundation
 
 public class BinaryStore: VectorStoreProtocol {
+    public init() {
+         print("Initted new BinaryStore")
+    }
     public func saveIndex(items: [IndexItem], to url: URL, as name: String) throws -> URL {
         let fileURL = url.appendingPathComponent("\(name).dat")
         var data = Data()

--- a/Tests/SimilaritySearchKitTests/SimilaritySearchKitTests.swift
+++ b/Tests/SimilaritySearchKitTests/SimilaritySearchKitTests.swift
@@ -14,7 +14,7 @@ import CoreML
 
 @available(macOS 13.0, iOS 16.0, *)
 class SimilaritySearchKitTests: XCTestCase {
-    func testSavingIndex() async {
+    func testSavingJsonIndex() async {
         let similarityIndex = await SimilarityIndex(model: DistilbertEmbeddings(), vectorStore: JsonStore())
 
         await similarityIndex.addItem(id: "1", text: "Example text", metadata: ["source": "test source"], embedding: [0.1, 0.2, 0.3])
@@ -23,8 +23,8 @@ class SimilaritySearchKitTests: XCTestCase {
 
         XCTAssertNotNil(successPath)
     }
-
-    func testLoadingIndex() async {
+    
+    func testLoadingJsonIndex() async {
         let similarityIndex = await SimilarityIndex(model: DistilbertEmbeddings(), vectorStore: JsonStore())
 
         await similarityIndex.addItem(id: "1", text: "Example text", metadata: ["source": "test source"])
@@ -34,6 +34,32 @@ class SimilaritySearchKitTests: XCTestCase {
         XCTAssertNotNil(successPath)
 
         let similarityIndex2 = await SimilarityIndex(model: DistilbertEmbeddings(), vectorStore: JsonStore())
+
+        let loadedItems = try! similarityIndex2.loadIndex(name: "TestIndexForLoading")
+
+        XCTAssertNotNil(loadedItems)
+    }
+
+    func testSavingBinaryIndex() async {
+        let similarityIndex = await SimilarityIndex(model: DistilbertEmbeddings(), vectorStore: BinaryStore())
+
+        await similarityIndex.addItem(id: "1", text: "Example text", metadata: ["source": "test source"], embedding: [0.1, 0.2, 0.3])
+
+        let successPath = try! similarityIndex.saveIndex(name: "TestIndexForSaving")
+
+        XCTAssertNotNil(successPath)
+    }
+
+    func testLoadingBinaryIndex() async {
+        let similarityIndex = await SimilarityIndex(model: DistilbertEmbeddings(), vectorStore: BinaryStore())
+
+        await similarityIndex.addItem(id: "1", text: "Example text", metadata: ["source": "test source"])
+
+        let successPath = try! similarityIndex.saveIndex(name: "TestIndexForLoading")
+
+        XCTAssertNotNil(successPath)
+
+        let similarityIndex2 = await SimilarityIndex(model: DistilbertEmbeddings(), vectorStore: BinaryStore())
 
         let loadedItems = try! similarityIndex2.loadIndex(name: "TestIndexForLoading")
 


### PR DESCRIPTION
**BinaryStore with compressed binary representation**
BinaryStore is 4.3x more efficient in disk-storage space than JsonStore. It compresses the data as well.

**Removed some fatal errors**
Some errors didn't seem to need to be fatal, so I made them non-fatal.

**SimilarityIndex.saveIndex and .loadIndex**
Both were private methods, which seemed not-ideal as I couldn't use them in my project. I made them public.