### PR TITLE
Support BERT style multilingual native embeddings

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
 
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
 
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
 
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
     - uses: actions/checkout@v3

--- a/Examples/BasicExample/BasicExample/ContentView.swift
+++ b/Examples/BasicExample/BasicExample/ContentView.swift
@@ -16,10 +16,16 @@ struct ContentView: View {
     @State private var querySentence: String = ""
     @State private var similarityResults: [SearchResult] = []
     @State private var similarityIndex: SimilarityIndex?
+    @State private var similarityIndexComparison: SimilarityIndex?
 
     func loadIndex() async {
+        var model: any EmbeddingsProtocol = MiniLMEmbeddings()
+        if #available(macOS 14.0, *) {
+            model = NativeContextualEmbeddings(language: .english)
+        }
+
         similarityIndex = await SimilarityIndex(
-            model: MiniLMEmbeddings(),
+            model: model,
             metric: CosineSimilarity()
         )
     }

--- a/Examples/BasicExample/BasicExample/ContentView.swift
+++ b/Examples/BasicExample/BasicExample/ContentView.swift
@@ -20,9 +20,9 @@ struct ContentView: View {
 
     func loadIndex() async {
         var model: any EmbeddingsProtocol = MiniLMEmbeddings()
-        if #available(macOS 14.0, *) {
-            model = NativeContextualEmbeddings(language: .english)
-        }
+        #if canImport(NaturalLanguage.NLContextualEmbedding)
+        embeddingModel = NativeContextualEmbeddings(language: .english)
+        #else
 
         similarityIndex = await SimilarityIndex(
             model: model,

--- a/Examples/ChatWithFilesExample/ChatWithFilesExample/ChatWithFilesExampleSwiftUIView.swift
+++ b/Examples/ChatWithFilesExample/ChatWithFilesExample/ChatWithFilesExampleSwiftUIView.swift
@@ -277,7 +277,6 @@ struct ChatWithFilesExampleSwiftUIView: View {
             #else
             embeddingModel = NativeEmbeddings()
             #endif
-            }
             currentTokenizer = NativeTokenizer()
         }
 

--- a/Examples/ChatWithFilesExample/ChatWithFilesExample/ChatWithFilesExampleSwiftUIView.swift
+++ b/Examples/ChatWithFilesExample/ChatWithFilesExample/ChatWithFilesExampleSwiftUIView.swift
@@ -272,7 +272,11 @@ struct ChatWithFilesExampleSwiftUIView: View {
             embeddingModel = MultiQAMiniLMEmbeddings()
             currentTokenizer = BertTokenizer()
         case .native:
-            embeddingModel = NativeEmbeddings()
+            if #available(macOS 14.0, *) {
+                embeddingModel = NativeContextualEmbeddings()
+            } else {
+                embeddingModel = NativeEmbeddings()
+            }
             currentTokenizer = NativeTokenizer()
         }
 

--- a/Examples/ChatWithFilesExample/ChatWithFilesExample/ChatWithFilesExampleSwiftUIView.swift
+++ b/Examples/ChatWithFilesExample/ChatWithFilesExample/ChatWithFilesExampleSwiftUIView.swift
@@ -272,10 +272,11 @@ struct ChatWithFilesExampleSwiftUIView: View {
             embeddingModel = MultiQAMiniLMEmbeddings()
             currentTokenizer = BertTokenizer()
         case .native:
-            if #available(macOS 14.0, *) {
-                embeddingModel = NativeContextualEmbeddings()
-            } else {
-                embeddingModel = NativeEmbeddings()
+            #if canImport(NaturalLanguage.NLContextualEmbedding)
+            embeddingModel = NativeContextualEmbeddings()
+            #else
+            embeddingModel = NativeEmbeddings()
+            #endif
             }
             currentTokenizer = NativeTokenizer()
         }

--- a/Sources/SimilaritySearchKit/Core/Embeddings/Models/NativeContextualEmbeddings.swift
+++ b/Sources/SimilaritySearchKit/Core/Embeddings/Models/NativeContextualEmbeddings.swift
@@ -1,0 +1,86 @@
+//
+//  NativeContextualEmbeddings.swift
+//  
+//
+//  Created by Zach Nagengast on 10/11/23.
+//
+
+import Foundation
+import NaturalLanguage
+import CoreML
+
+@available(macOS 14.0, iOS 17.0, *)
+public class NativeContextualEmbeddings: EmbeddingsProtocol {
+    public let model: ModelActor
+    public let tokenizer: any TokenizerProtocol
+
+    // Initialize with a language
+    public init(language: NLLanguage = .english) {
+        self.tokenizer = NativeTokenizer()
+        guard let nativeModel = NLContextualEmbedding(language: language) else {
+            fatalError("Failed to load the Core ML model.")
+        }
+        Self.initializeModel(nativeModel)
+        self.model = ModelActor(model: nativeModel)
+    }
+
+    // Initialize with a script
+    public init(script: NLScript) {
+        self.tokenizer = NativeTokenizer()
+        guard let nativeModel = NLContextualEmbedding(script: script) else {
+            fatalError("Failed to load the Core ML model.")
+        }
+        Self.initializeModel(nativeModel)
+        self.model = ModelActor(model: nativeModel)
+    }
+
+    // Common model initialization logic
+    private static func initializeModel(_ nativeModel: NLContextualEmbedding) {
+        if !nativeModel.hasAvailableAssets {
+            nativeModel.requestAssets { _, _ in }
+        }
+        try! nativeModel.load()
+    }
+
+    // MARK: - Dense Embeddings
+
+    public actor ModelActor {
+        private let model: NLContextualEmbedding
+
+        init(model: NLContextualEmbedding) {
+            self.model = model
+        }
+
+        func vector(for sentence: String) -> [Float]? {
+            // Obtain embedding result for the given sentence
+            // Shape is [1, embedding.sequenceLength, model.dimension]
+            let embedding = try! model.embeddingResult(for: sentence, language: nil)
+
+            // Initialize an array to store the total embedding values and set the count
+            var meanPooledEmbeddings: [Float] = Array(repeating: 0.0, count: model.dimension)
+            let sequenceLength = embedding.sequenceLength
+
+            // Mean pooling: Loop through each token vector in the embedding and sum the values
+            embedding.enumerateTokenVectors(in: sentence.startIndex ..< sentence.endIndex) { (embedding, _) -> Bool in
+                for tokenEmbeddingIndex in 0 ..< embedding.count {
+                    meanPooledEmbeddings[tokenEmbeddingIndex] += Float(embedding[tokenEmbeddingIndex])
+                }
+                return true
+            }
+
+            // Mean pooling: Get the average embedding from totals
+            if sequenceLength > 0 {
+                for index in 0 ..< sequenceLength {
+                    meanPooledEmbeddings[index] /= Float(sequenceLength)
+                }
+            }
+
+            // Return the mean-pooled vector
+            return meanPooledEmbeddings
+        }
+    }
+
+    public func encode(sentence: String) async -> [Float]? {
+        return await model.vector(for: sentence)
+    }
+}

--- a/Sources/SimilaritySearchKit/Core/Embeddings/Models/NativeContextualEmbeddings.swift
+++ b/Sources/SimilaritySearchKit/Core/Embeddings/Models/NativeContextualEmbeddings.swift
@@ -9,6 +9,7 @@ import Foundation
 import NaturalLanguage
 import CoreML
 
+#if canImport(NaturalLanguage.NLContextualEmbedding)
 @available(macOS 14.0, iOS 17.0, *)
 public class NativeContextualEmbeddings: EmbeddingsProtocol {
     public let model: ModelActor
@@ -84,3 +85,5 @@ public class NativeContextualEmbeddings: EmbeddingsProtocol {
         return await model.vector(for: sentence)
     }
 }
+#endif
+

--- a/Sources/SimilaritySearchKit/Core/Embeddings/Models/NativeEmbeddings.swift
+++ b/Sources/SimilaritySearchKit/Core/Embeddings/Models/NativeEmbeddings.swift
@@ -10,11 +10,12 @@ import NaturalLanguage
 
 @available(macOS 11.0, iOS 15.0, *)
 public class NativeEmbeddings: EmbeddingsProtocol {
-    public let model = ModelActor()
+    public let model: ModelActor
     public let tokenizer: any TokenizerProtocol
 
-    public init() {
+    public init(language: NLLanguage = .english) {
         self.tokenizer = NativeTokenizer()
+        self.model = ModelActor(language: language)
     }
 
     // MARK: - Dense Embeddings
@@ -22,8 +23,8 @@ public class NativeEmbeddings: EmbeddingsProtocol {
     public actor ModelActor {
         private let model: NLEmbedding
 
-        init() {
-            guard let nativeModel = NLEmbedding.sentenceEmbedding(for: .english) else {
+        init(language: NLLanguage) {
+            guard let nativeModel = NLEmbedding.sentenceEmbedding(for: language) else {
                 fatalError("Failed to load the Core ML model.")
             }
             model = nativeModel

--- a/Tests/SimilaritySearchKitTests/SimilaritySearchKitTests.swift
+++ b/Tests/SimilaritySearchKitTests/SimilaritySearchKitTests.swift
@@ -14,6 +14,12 @@ import CoreML
 
 @available(macOS 13.0, iOS 16.0, *)
 class SimilaritySearchKitTests: XCTestCase {
+
+    override func setUp() {
+        executionTimeAllowance = 60
+        continueAfterFailure = true
+    }
+
     func testSavingJsonIndex() async {
         let similarityIndex = await SimilarityIndex(model: DistilbertEmbeddings(), vectorStore: JsonStore())
 


### PR DESCRIPTION
Based on this request https://github.com/ZachNagengast/similarity-search-kit/issues/21#issuecomment-1749619786

From WWDC23: https://developer.apple.com/videos/play/wwdc2023/10042/

This new API is iOS 17/macOS 14 only and requires a pooling step to get it into the same format as the sentence transformer models, this PR is using mean pooling to try to capture the general meaning of the sentence. It's still not the most accurate model for QA tasks, but it does find similarities fairly well.

Comparison to a similar BERT based model:
<img width="1097" alt="image" src="https://github.com/ZachNagengast/similarity-search-kit/assets/1981179/2fd8e58a-588f-4902-a992-ed6e677900e9">
