### PR TITLE
Fix load index

### DIFF
--- a/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
+++ b/Sources/SimilaritySearchKit/Core/Index/SimilarityIndex.swift
@@ -326,11 +326,9 @@ extension SimilarityIndex {
 
     public func loadIndex(fromDirectory path: URL? = nil, name: String? = nil) throws -> [IndexItem]? {
         if let indexPath = try getIndexPath(fromDirectory: path, name: name) {
-            let loadedIndexItems = try vectorStore.loadIndex(from: indexPath)
-            addItems(loadedIndexItems) {[self] in
-                print("Loaded \(indexItems.count) index items from \(indexPath.absoluteString)")
-            }
-            return loadedIndexItems
+            indexItems = try vectorStore.loadIndex(from: indexPath)
+            print("Loaded \(indexItems.count) index items from \(indexPath.absoluteString)")
+            return indexItems
         }
 
         return nil


### PR DESCRIPTION
Hi, @ZachNagengast 

The loadIndex method has already loaded the embedding, and there is no need to call addItem. The original method is very slow in some cases. FIY [https://github.com/buhe/langchain-swift/blob/main/Sources/LangChain/vectorstores/SimilaritySearchKit.swift #L35](https://github.com/buhe/langchain-swift/blob/main/Sources/LangChain/vectorstores/SimilaritySearchKit.swift#L35) with openaiembedding

BR
buhe